### PR TITLE
filter out short and null holdings

### DIFF
--- a/3_run_analysis.R
+++ b/3_run_analysis.R
@@ -53,7 +53,7 @@ if (file.exists(equity_input_file)) {
 
     port_eq <- calculate_weights(port_raw_eq, "Equity", grouping_variables)
     
-    port_eq <- port_eq %>% filter(port_weight > 0)  # filter out short and null holdings
+    port_eq <- port_eq %>% dplyr::filter(port_weight > 0)  # filter out short and null holdings
 
     port_eq <- merge_in_ald(port_eq, ald_scen_eq)
 
@@ -155,7 +155,7 @@ if (file.exists(bonds_inputs_file)) {
 
     port_cb <- calculate_weights(port_raw_cb, "Bonds", grouping_variables)
     
-    port_cb <- port_cb %>% filter(port_weight > 0)  # filter our short and null holdings
+    port_cb <- port_cb %>% dplyr::filter(port_weight > 0)  # filter our short and null holdings
 
     port_cb <- merge_in_ald(port_cb, ald_scen_cb)
 

--- a/3_run_analysis.R
+++ b/3_run_analysis.R
@@ -52,6 +52,8 @@ if (file.exists(equity_input_file)) {
     port_raw_eq <- port_raw_all_eq %>% filter(investor_name == investor_name_select)
 
     port_eq <- calculate_weights(port_raw_eq, "Equity", grouping_variables)
+    
+    port_eq <- port_eq %>% filter(port_weight > 0)  # filter out short and null holdings
 
     port_eq <- merge_in_ald(port_eq, ald_scen_eq)
 
@@ -152,6 +154,8 @@ if (file.exists(bonds_inputs_file)) {
     port_raw_cb <- port_raw_all_cb %>% filter(investor_name == investor_name_select)
 
     port_cb <- calculate_weights(port_raw_cb, "Bonds", grouping_variables)
+    
+    port_cb <- port_cb %>% filter(port_weight > 0)  # filter our short and null holdings
 
     port_cb <- merge_in_ald(port_cb, ald_scen_cb)
 


### PR DESCRIPTION
related to ADO-661
supersedes #499 

This is @FrederickFa's suggested (quick but not ideal) change to address the problem discussed in #499. This is also discussed in ADO#661, where there seems to be still some debate on the proper long term solution.

~~This only changes the so-called "offline" version, which may be only used by MFM anymore, though we can't really know that for sure.~~ This will also impact what runs on transitionmonitor